### PR TITLE
🔧 Change `auth` middleware to `api`

### DIFF
--- a/app/Bot.php
+++ b/app/Bot.php
@@ -12,8 +12,12 @@ class Bot extends Laracord
      */
     public function routes(): void
     {
-        Route::middleware('auth')->group(function () {
-            // Route::get('/', fn () => collect($this->registeredCommands)->map(fn ($command) => [
+        Route::middleware('web')->group(function () {
+            // Route::get('/', fn () => 'Hello world!');
+        });
+
+        Route::middleware('api')->group(function () {
+            // Route::get('/commands', fn () => collect($this->registeredCommands)->map(fn ($command) => [
             //     'signature' => $command->getSignature(),
             //     'description' => $command->getDescription(),
             // ]));


### PR DESCRIPTION
## Change log

### Enhancements

- 🔧 Change `auth` middleware to `api`
- 🔧 Add `web` middleware example